### PR TITLE
Relative imports, bug fix in __and__, and extra type annotations.

### DIFF
--- a/src/pylo/engines/GnuProlog.py
+++ b/src/pylo/engines/GnuProlog.py
@@ -1,8 +1,12 @@
-from src.pylo import (
-    Prolog
-)
-from src.pylo import Constant, Variable, Functor, Structure, List, Literal, Negation, Clause, \
+# from src.pylo import (
+#     Prolog
+# )
+# from  import Constant, Variable, Functor, Structure, List, Literal, Negation, Clause, \
+#     global_context
+from .Prolog import Prolog
+from .language import Constant, Variable, Functor, Structure, List, Literal, Negation, Clause, \
     global_context
+
 import sys
 sys.path.append("../../../build")
 

--- a/src/pylo/engines/SWIProlog.py
+++ b/src/pylo/engines/SWIProlog.py
@@ -1,9 +1,14 @@
-from src.pylo import (
-    Prolog
-)
-from src.pylo import Constant, Variable, Functor, Structure, List, Predicate, Literal, Negation, Clause, \
-    global_context
+# from src.pylo import (
+#     Prolog
+# )
+# from src.pylo import Constant, Variable, Functor, Structure, List, Predicate, Literal, Negation, Clause, \
+#     global_context
+from .Prolog import Prolog
+from .language import Constant, Variable, Functor, Structure, Predicate, List, Literal, Negation, Conj, Clause, \
+    global_context, list_func
+import typing
 import sys
+
 sys.path.append("../../../build")
 
 import swipy
@@ -175,17 +180,21 @@ def _conjoin_literals(lits: Sequence[int]):
         compound_arg = swipy.swipy_new_term_refs(2)
         conj = swipy.swipy_new_term_ref()
         swipy.swipy_put_term(compound_arg, lits[0])
-        swipy.swipy_put_term(compound_arg+1, _conjoin_literals(lits[1:]))
+        swipy.swipy_put_term(compound_arg + 1, _conjoin_literals(lits[1:]))
         swipy.swipy_cons_functor(conj, conj_functor, compound_arg)
 
         return conj
 
 
 def _cl_to_swipy(clause: Clause, lit_var_store: Dict[Variable, int]):
-    body = clause.get_body().get_literals()
-    head = clause.get_head()
+    body: typing.List[Literal] = clause.get_body().get_literals()
+    head: Literal = clause.get_head()
 
-    body = [_lit_to_swipy(x, lit_var_store) if isinstance(x, Literal) else _neg_to_swipy(x, lit_var_store) for x in body]
+    body: typing.List[int] = [_lit_to_swipy(x, lit_var_store)
+                              if isinstance(x, Literal)
+                              else _neg_to_swipy(x, lit_var_store)
+                              for x in body]
+
     head = _lit_to_swipy(head, lit_var_store)
     body = _conjoin_literals(body)
 
@@ -195,7 +204,7 @@ def _cl_to_swipy(clause: Clause, lit_var_store: Dict[Variable, int]):
     entire_clause = swipy.swipy_new_term_ref()
     compound_arg = swipy.swipy_new_term_refs(2)
     swipy.swipy_put_term(compound_arg, head)
-    swipy.swipy_put_term(compound_arg+1, body)
+    swipy.swipy_put_term(compound_arg + 1, body)
     swipy.swipy_cons_functor(entire_clause, clause_functor, compound_arg)
 
     return entire_clause
@@ -225,7 +234,8 @@ def _swipy_to_var(term, swipy_term_to_var: Dict[int, Variable]):
         all_var_names = set([x.get_name() for x in swipy_term_to_var.values()])
         new_name = [chr(x) for x in range(ord('A'), ord('Z') + 1) if chr(x) not in all_var_names][0]
         if len(new_name) == 0:
-            new_name = [f"{chr(x)}{chr(y)}" for x in range(ord('A'), ord('Z')+1) for y in range(ord('A'), ord('Z')+1) if f"{chr(x)}{chr(y)}" not in all_var_names]
+            new_name = [f"{chr(x)}{chr(y)}" for x in range(ord('A'), ord('Z') + 1) for y in
+                        range(ord('A'), ord('Z') + 1) if f"{chr(x)}{chr(y)}" not in all_var_names]
         new_var = Variable(new_name)
         swipy_term_to_var[term] = new_var
         return new_var
@@ -292,7 +302,7 @@ class SWIProlog(Prolog):
 
     def consult(self, filename: str):
         string_term = swipy.swipy_new_term_ref()
-        swipy.swipy_put_string_chars(string_term,  filename)
+        swipy.swipy_put_string_chars(string_term, filename)
 
         consult_pred = swipy.swipy_predicate("consult", 1, None)
         query = swipy.swipy_open_query(consult_pred, string_term)
@@ -347,7 +357,7 @@ class SWIProlog(Prolog):
 
         return r
 
-    def assertz(self, clause):
+    def assertz(self, clause: Union[Literal, Clause]):
         var_store = {}
         if isinstance(clause, Literal):
             swipl_object = _lit_to_swipy(clause, var_store)
@@ -380,7 +390,7 @@ class SWIProlog(Prolog):
             query_args = swipy.swipy_new_term_refs(query.get_predicate().get_arity())
 
             for ind, arg in enumerate(query.get_arguments()):
-                _to_swipy_ref(arg, query_args+ind, var_store)
+                _to_swipy_ref(arg, query_args + ind, var_store)
 
             pred = swipy.swipy_predicate(predicate_name, query.get_predicate().get_arity(), None)
             query = swipy.swipy_open_query(pred, query_args)
@@ -389,13 +399,14 @@ class SWIProlog(Prolog):
 
             return True if r else False
         else:
-            swipy_objs = [_lit_to_swipy(x, var_store) if isinstance(x, Literal) else _neg_to_swipy(x, var_store) for x in query]
+            swipy_objs = [_lit_to_swipy(x, var_store) if isinstance(x, Literal) else _neg_to_swipy(x, var_store) for x
+                          in query]
             first = swipy_objs[0]
             rest = _conjoin_literals(swipy_objs[1:])
 
             compound_arg = swipy.swipy_new_term_refs(2)
             swipy.swipy_put_term(compound_arg, first)
-            swipy.swipy_put_term(compound_arg+1, rest)
+            swipy.swipy_put_term(compound_arg + 1, rest)
 
             predicate = swipy.swipy_predicate(",", 2, None)
             query = swipy.swipy_open_query(predicate, compound_arg)
@@ -425,18 +436,19 @@ class SWIProlog(Prolog):
             query_args = swipy.swipy_new_term_refs(query.get_predicate().get_arity())
 
             for ind, arg in enumerate(query.get_arguments()):
-                _to_swipy_ref(arg, query_args+ind, var_store)
+                _to_swipy_ref(arg, query_args + ind, var_store)
 
             pred = swipy.swipy_predicate(predicate_name, query.get_predicate().get_arity(), None)
             query = swipy.swipy_open_query(pred, query_args)
         else:
-            swipy_objs = [_lit_to_swipy(x, var_store) if isinstance(x, Literal) else _neg_to_swipy(x, var_store) for x in query]
+            swipy_objs = [_lit_to_swipy(x, var_store) if isinstance(x, Literal) else _neg_to_swipy(x, var_store) for x
+                          in query]
             first = swipy_objs[0]
             rest = _conjoin_literals(swipy_objs[1:])
 
             compound_arg = swipy.swipy_new_term_refs(2)
             swipy.swipy_put_term(compound_arg, first)
-            swipy.swipy_put_term(compound_arg+1, rest)
+            swipy.swipy_put_term(compound_arg + 1, rest)
 
             predicate = swipy.swipy_predicate(",", 2, None)
             query = swipy.swipy_open_query(predicate, compound_arg)
@@ -514,15 +526,3 @@ if __name__ == '__main__':
 
     rv = pl.query(query3)
     print("all solutions after adding list ", rv)
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/pylo/engines/XSBProlog.py
+++ b/src/pylo/engines/XSBProlog.py
@@ -1,7 +1,10 @@
-from src.pylo import (
-    Prolog
-)
-from src.pylo import Variable, Structure, List, Literal, Clause, global_context
+# from src.pylo import (
+#     Prolog
+# )
+# from src.pylo import Variable, Structure, List, Literal, Clause, global_context
+
+from .Prolog import Prolog
+from .language import Variable, Structure, List, Literal, Clause, global_context
 import sys
 
 #sys.path.append("../../build")

--- a/src/pylo/engines/language.py
+++ b/src/pylo/engines/language.py
@@ -1,13 +1,14 @@
 from abc import ABC
 from typing import Sequence, Union
+import typing
 
 
 class Term(ABC):
 
-    def __init__(self, name):
-        self._name = name
+    def __init__(self, name: str):
+        self._name: str = name
 
-    def get_name(self):
+    def get_name(self) -> str:
         return self._name
 
     def __eq__(self, other):
@@ -40,13 +41,13 @@ class Variable(Term):
 class Functor:
 
     def __init__(self, name: str, arity: int):
-        self._name = name
-        self._arity = arity
+        self._name: str = name
+        self._arity: int = arity
 
-    def get_name(self):
+    def get_name(self) -> str:
         return self._name
 
-    def get_arity(self):
+    def get_arity(self) -> int:
         return self._arity
 
     def __eq__(self, other):
@@ -61,9 +62,10 @@ class Functor:
     def __repr__(self):
         return self._name
 
-    def __call__(self, *args):
+    def __call__(self, *args: Union[str, "Constant", "Variable", "Structure", "List", int, float]) -> "Structure":
         args_to_use = []
         global global_context
+        elem: Union[str, "Constant", "Variable", "Structure", "List", int, float]
         for elem in args:
             if isinstance(elem, str) and elem.islower():
                 args_to_use.append(global_context.get_constant(elem))
@@ -79,15 +81,15 @@ class Functor:
 
 class Structure(Term):
 
-    def __init__(self, functor: Functor, args: Sequence[Union[Term, int, float]]):
-        self._functor = functor
-        self._args = args
+    def __init__(self, functor: "Functor", args: Sequence[Union[Term, int, float]]):
+        self._functor: Functor = functor
+        self._args: Sequence[Union[Term, int, float]] = args
         super().__init__(name=functor.get_name())
 
-    def get_functor(self):
+    def get_functor(self) -> Functor:
         return self._functor
 
-    def get_arguments(self):
+    def get_arguments(self) -> Sequence[Union[Term, int, float]]:
         return self._args
 
     def __eq__(self, other):
@@ -133,13 +135,13 @@ class List(Structure):
 class Predicate:
 
     def __init__(self, name: str, arity: int):
-        self._name = name
-        self._arity = arity
+        self._name: str = name
+        self._arity: int = arity
 
-    def get_name(self):
+    def get_name(self) -> str:
         return self._name
 
-    def get_arity(self):
+    def get_arity(self) -> int:
         return self._arity
 
     def __eq__(self, other):
@@ -154,9 +156,10 @@ class Predicate:
     def __repr__(self):
         return self._name
 
-    def __call__(self, *args):
+    def __call__(self, *args: Union[str, "Constant", "Variable", "Structure", "Predicate", int, float]) -> "Literal":
         argsToUse = []
         # global global_context
+        elem: Union[str, "Constant", "Variable", "Structure", "Predicate", int, float]
         for elem in args:
             if isinstance(elem, str) and elem.isdigit():
                 if '.' in elem:
@@ -181,28 +184,28 @@ class Literal:
 
     def __init__(self, predicate: Predicate, args: Sequence[Union[Term, int, float]]):
         self._predicate = predicate
-        self._args = args
+        self._args: Sequence[Union[Term, int, float]] = args
 
-    def get_predicate(self):
+    def get_predicate(self) -> Predicate:
         return self._predicate
 
-    def get_arguments(self):
+    def get_arguments(self) -> Sequence[Union[Term, int, float]]:
         return self._args
 
-    def __and__(self, other: Union["Literal", "Negation"]):
+    def __and__(self, other: Union["Literal", "Negation"]) -> "Conj":
         return Conj(self, other)
 
-    def __le__(self, other: Union["Literal", "Negation", "Conj"]):
+    def __le__(self, other: Union["Literal", "Negation", "Conj"]) -> "Clause":
         if isinstance(other, (Literal, Negation)):
             return Clause(self, Conj(other))
         else:
             return Clause(self, other)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if isinstance(other, Literal):
-            return self._predicate == other._predicate and\
-                    len(self._args) == len(other._args) and\
-                    all([x == y for x, y in zip(self._args, other._args)])
+            return self._predicate == other._predicate and \
+                   len(self._args) == len(other._args) and \
+                   all([x == y for x, y in zip(self._args, other._args)])
         else:
             return False
 
@@ -216,12 +219,12 @@ class Literal:
 class Negation:
 
     def __init__(self, literal: Literal):
-        self._lit = literal
+        self._lit: Literal = literal
 
-    def get_literal(self):
+    def get_literal(self) -> "Literal":
         return self._lit
 
-    def __and__(self, other: Union["Literal", "Negation"]):
+    def __and__(self, other: Union["Literal", "Negation"]) -> "Conj":
         return Conj(self, other)
 
     def __eq__(self, other):
@@ -236,16 +239,16 @@ class Negation:
 
 class Conj:
 
-    def __init__(self, *lits):
-        self._lits = list(lits)
+    def __init__(self, *lits: Union["Literal", "Negation"]):
+        self._lits: typing.List[Union["Literal", "Negation"]] = list(lits)
 
-    def get_literals(self):
+    def get_literals(self) -> typing.List[Union["Literal", "Negation"]]:
         return self._lits
 
     def __repr__(self):
         return ",".join([str(x) for x in self._lits])
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if isinstance(other, Conj):
             return all([x == y for x, y in zip(self._lits, other._lits)])
         else:
@@ -254,25 +257,26 @@ class Conj:
     def __hash__(self):
         return hash(str(self))
 
-    def __and__(self, other: Union["Literal", "Negation", "Conj"]):
+    def __and__(self, other: Union["Literal", "Negation", "Conj"]) -> "Conj":
         if isinstance(other, (Literal, Negation)):
             self._lits += [other]
         elif isinstance(other, Conj):
             self._lits += other.get_literals()
         else:
             raise Exception(f"Don't know how to add object of type {type(other)} to Conj")
+        return self
 
 
 class Clause:
 
     def __init__(self, head: Literal, body: Conj):
-        self._head = head
-        self._body = body
+        self._head: Literal = head
+        self._body: Conj = body
 
-    def get_head(self):
+    def get_head(self) -> Literal:
         return self._head
 
-    def get_body(self):
+    def get_body(self) -> Conj:
         return self._body
 
     def __and__(self, other: Union["Literal", "Negation", "Conj"]):
@@ -308,9 +312,10 @@ class Context:
         return self._vars[name]
 
     def get_fresh_variable(self, save=False):
-        name = [chr(x) for x in range(ord('A'), ord('Z')+1) if chr(x) not in self._vars][0]
+        name = [chr(x) for x in range(ord('A'), ord('Z') + 1) if chr(x) not in self._vars][0]
         if len(name) == 0:
-            name = [f"{chr(x)}{chr(y)}" for x in range(ord('A'), ord('Z') + 1) for y in range(ord('A'), ord('Z') + 1) if chr(x) not in self._vars][0]
+            name = [f"{chr(x)}{chr(y)}" for x in range(ord('A'), ord('Z') + 1) for y in range(ord('A'), ord('Z') + 1) if
+                    chr(x) not in self._vars][0]
         var = Variable(name)
 
         if save:


### PR DESCRIPTION
- Changed absolute module import to be relative imports in engines.<PrologEngine>.py, to avoid name clashes with other directories named 'src'. (e.g. when this package is installed in other projects.) 

- Fixed a bug in 'language.py', where the method __and__ of Conj did not return anything (and thus returned None, the default value). Now, the Conj object itself is returned.

- Added extra type annotations in language.py.