### PR TITLE
Fix substitution for Terms and Predicates

### DIFF
--- a/src/pylo/language/commons.py
+++ b/src/pylo/language/commons.py
@@ -602,11 +602,11 @@ class Body:
         return vars_ordered
 
     def substitute(self, term_map: Dict[Term, Term]):
-        return Body([x.substitute(term_map) for x in self._literals])
+        return Body(*[x.substitute(term_map) for x in self._literals])
 
     def substitute_predicate(self, old_predicate: Predicate, new_predicate: Predicate):
         return Body(
-            [
+            *[
                 x
                 if x.get_predicate() != old_predicate
                 else new_predicate(*x.get_arguments())


### PR DESCRIPTION
Fixes #10 

Before, ```Body.substitute()``` and ```Body.substitute_predicate()``` returned a list of Atoms but the constructor of Body expected a variable number of Atoms, thus interpreting is as one argument of type `<list>`. Expanding the list using * fixes this. 