### PR TITLE
Add retract_all() for Prolog engines

### DIFF
--- a/src/pylo/engines/prolog/GnuProlog.py
+++ b/src/pylo/engines/prolog/GnuProlog.py
@@ -304,12 +304,10 @@ class GNUProlog(Prolog):
             return self._retract_cl(clause)
 
     def retract_all(self):
-        for cl in self._asserted_clauses:
+        for cl in [cl for cl in self._asserted_clauses]:
             self.retract(cl)
-        for atom in self._asserted_atoms:
+        for atom in  [cl for cl in self._asserted_atoms]:
             self.retract(atom)
-        self._asserted_clauses = set()
-        self._asserted_atoms = set()
 
     def has_solution(self, *query: Union[Atom, Not]):
         var_store = {}

--- a/src/pylo/engines/prolog/GnuProlog.py
+++ b/src/pylo/engines/prolog/GnuProlog.py
@@ -186,6 +186,9 @@ class GNUProlog(Prolog):
 
     def __init__(self):
         pygprolog.pygp_Start_Prolog()
+
+        self._asserted_atoms = set()
+        self._asserted_clauses = set()
         super().__init__()
 
     def release(self):
@@ -210,25 +213,27 @@ class GNUProlog(Prolog):
         raise Exception(f"GNUProlog does not have modules.")
 
     def _asserta_lit(self, literal: Atom):
-        pl = _lit_to_pygp(literal)
-        asa_p = pygprolog.pygp_Find_Atom("asserta")
+        if literal not in self._asserted_atoms:
+            pl = _lit_to_pygp(literal)
+            asa_p = pygprolog.pygp_Find_Atom("asserta")
 
-        pygprolog.pygp_Query_Begin()
-        q_Var1 = pygprolog.pygp_Query_Call(asa_p, 1, [pl])
-        pygprolog.pygp_Query_End()
+            pygprolog.pygp_Query_Begin()
+            q_Var1 = pygprolog.pygp_Query_Call(asa_p, 1, [pl])
+            pygprolog.pygp_Query_End()
 
-        return q_Var1
+            return q_Var1
 
     def _asserta_cl(self, clause: Clause):
-        clp = _cl_to_pygp(clause)
+        if clause not in self._asserted_clauses:
+            clp = _cl_to_pygp(clause)
 
-        asa_p = pygprolog.pygp_Find_Atom("asserta")
+            asa_p = pygprolog.pygp_Find_Atom("asserta")
 
-        pygprolog.pygp_Query_Begin()
-        q_Var1 = pygprolog.pygp_Query_Call(asa_p, 1, [clp])
-        pygprolog.pygp_Query_End()
+            pygprolog.pygp_Query_Begin()
+            q_Var1 = pygprolog.pygp_Query_Call(asa_p, 1, [clp])
+            pygprolog.pygp_Query_End()
 
-        return q_Var1
+            return q_Var1
 
     def asserta(self, clause: Union[Atom, Clause]):
         if isinstance(clause, Atom):
@@ -237,25 +242,27 @@ class GNUProlog(Prolog):
             return self._asserta_cl(clause)
 
     def _assertz_lit(self, literal: Atom):
-        pl = _lit_to_pygp(literal)
-        asa_p = pygprolog.pygp_Find_Atom("assertz")
+        if literal not in self._asserted_atoms:
+            pl = _lit_to_pygp(literal)
+            asa_p = pygprolog.pygp_Find_Atom("assertz")
 
-        pygprolog.pygp_Query_Begin()
-        q_Var1 = pygprolog.pygp_Query_Call(asa_p, 1, [pl])
-        pygprolog.pygp_Query_End()
+            pygprolog.pygp_Query_Begin()
+            q_Var1 = pygprolog.pygp_Query_Call(asa_p, 1, [pl])
+            pygprolog.pygp_Query_End()
 
-        return q_Var1
+            return q_Var1
 
     def _assertz_cl(self, clause: Clause):
-        clp = _cl_to_pygp(clause)
+        if clause not in self._asserted_clauses:
+            clp = _cl_to_pygp(clause)
 
-        asa_p = pygprolog.pygp_Find_Atom("assertz")
+            asa_p = pygprolog.pygp_Find_Atom("assertz")
 
-        pygprolog.pygp_Query_Begin()
-        q_Var1 = pygprolog.pygp_Query_Call(asa_p, 1, [clp])
-        pygprolog.pygp_Query_End()
+            pygprolog.pygp_Query_Begin()
+            q_Var1 = pygprolog.pygp_Query_Call(asa_p, 1, [clp])
+            pygprolog.pygp_Query_End()
 
-        return q_Var1
+            return q_Var1
 
     def assertz(self, clause: Union[Atom, Clause]):
         if isinstance(clause, Atom):
@@ -264,31 +271,45 @@ class GNUProlog(Prolog):
             return self._assertz_cl(clause)
 
     def _retract_lit(self, literal: Atom):
-        pl = _lit_to_pygp(literal)
-        asa_p = pygprolog.pygp_Find_Atom("retract")
+        if literal in self._asserted_atoms:
+            pl = _lit_to_pygp(literal)
+            asa_p = pygprolog.pygp_Find_Atom("retract")
 
-        pygprolog.pygp_Query_Begin()
-        q_Var1 = pygprolog.pygp_Query_Call(asa_p, 1, [pl])
-        pygprolog.pygp_Query_End()
+            pygprolog.pygp_Query_Begin()
+            q_Var1 = pygprolog.pygp_Query_Call(asa_p, 1, [pl])
+            pygprolog.pygp_Query_End()
 
-        return q_Var1
+            self._asserted_atoms.remove(literal)
+
+            return q_Var1
 
     def _retract_cl(self, clause: Clause):
-        clp = _cl_to_pygp(clause)
+        if clause in self._asserted_clauses:
+            clp = _cl_to_pygp(clause)
 
-        asa_p = pygprolog.pygp_Find_Atom("retract")
+            asa_p = pygprolog.pygp_Find_Atom("retract")
 
-        pygprolog.pygp_Query_Begin()
-        q_Var1 = pygprolog.pygp_Query_Call(asa_p, 1, [clp])
-        pygprolog.pygp_Query_End()
+            pygprolog.pygp_Query_Begin()
+            q_Var1 = pygprolog.pygp_Query_Call(asa_p, 1, [clp])
+            pygprolog.pygp_Query_End()
 
-        return q_Var1
+            self._asserted_clauses.remove(clause)
+
+            return q_Var1
 
     def retract(self, clause: Union[Atom, Clause]):
         if isinstance(clause, Atom):
             return self._retract_lit(clause)
         if isinstance(clause, Clause):
             return self._retract_cl(clause)
+
+    def retract_all(self):
+        for cl in self._asserted_clauses:
+            self.retract(cl)
+        for atom in self._asserted_atoms:
+            self.retract(atom)
+        self._asserted_clauses = set()
+        self._asserted_atoms = set()
 
     def has_solution(self, *query: Union[Atom, Not]):
         var_store = {}

--- a/src/pylo/engines/prolog/SWIProlog.py
+++ b/src/pylo/engines/prolog/SWIProlog.py
@@ -454,7 +454,6 @@ class SWIProlog(Prolog):
     def retract_all(self):
         for cl in [cl for cl in self._asserted_clauses]:
             self.retract(cl)
-        self._asserted_clauses = set()
 
     def has_solution(self, *query: Union[Atom, Not]):
         var_store = {}

--- a/src/pylo/engines/prolog/SWIProlog.py
+++ b/src/pylo/engines/prolog/SWIProlog.py
@@ -341,6 +341,8 @@ class SWIProlog(Prolog):
         self._callback_arities = {}
         self._wrapped_functions = {}
         self._wrap_refs_to_keep = []
+        self._asserted_clauses = set()
+
         super(SWIProlog, self).__init__()
 
     def release(self):
@@ -396,47 +398,63 @@ class SWIProlog(Prolog):
         return r
 
     def asserta(self, clause):
-        var_store = {}
-        if isinstance(clause, Atom):
-            swipl_object = _lit_to_swipy(clause, var_store)
-        else:
-            swipl_object = _cl_to_swipy(clause, var_store)
+        if not clause in self._asserted_clauses:
+            var_store = {}
+            if isinstance(clause, Atom):
+                swipl_object = _lit_to_swipy(clause, var_store)
+            else:
+                swipl_object = _cl_to_swipy(clause, var_store)
 
-        asserta = swipy.swipy_predicate("asserta", 1, None)
-        query = swipy.swipy_open_query(asserta, swipl_object)
-        r = swipy.swipy_next_solution(query)
-        swipy.swipy_close_query(query)
+            asserta = swipy.swipy_predicate("asserta", 1, None)
+            query = swipy.swipy_open_query(asserta, swipl_object)
+            r = swipy.swipy_next_solution(query)
+            swipy.swipy_close_query(query)
 
-        return r
+            self._asserted_clauses.add(clause)
+
+            return r
 
     def assertz(self, clause: Union[Atom, Clause]):
-        var_store = {}
-        if isinstance(clause, Atom):
-            swipl_object = _lit_to_swipy(clause, var_store)
-        elif isinstance(clause, Clause):
-            swipl_object = _cl_to_swipy(clause, var_store)
-        else:
-            raise Exception(f"can only assertz atoms or clauses (got {clause})")
+        if not clause in self._asserted_clauses:
+            var_store = {}
+            if isinstance(clause, Atom):
+                swipl_object = _lit_to_swipy(clause, var_store)
+            elif isinstance(clause, Clause):
+                swipl_object = _cl_to_swipy(clause, var_store)
+            else:
+                raise Exception(f"can only assertz atoms or clauses (got {clause})")
 
-        asserta = swipy.swipy_predicate("assertz", 1, None)
-        query = swipy.swipy_open_query(asserta, swipl_object)
-        r = swipy.swipy_next_solution(query)
-        swipy.swipy_close_query(query)
+            asserta = swipy.swipy_predicate("assertz", 1, None)
+            query = swipy.swipy_open_query(asserta, swipl_object)
+            r = swipy.swipy_next_solution(query)
+            swipy.swipy_close_query(query)
 
-        return r
+            self._asserted_clauses.add(clause)
+
+            return r
 
     def retract(self, clause: Union[Atom, Clause]):
-        if isinstance(clause, Atom):
-            lit = _lit_to_swipy(clause, {})
+        if clause in self._asserted_clauses:
+            if isinstance(clause, Atom):
+                lit = _lit_to_swipy(clause, {})
+            else:
+                lit = _cl_to_swipy(clause, {})
+
+            retract = swipy.swipy_predicate("retract", 1, None)
+            query = swipy.swipy_open_query(retract, lit)
+            r = swipy.swipy_next_solution(query)
+            swipy.swipy_close_query(query)
+
+            self._asserted_clauses.remove(clause)
+
+            return r
         else:
-            lit = _cl_to_swipy(clause, {})
+            print("Clause {} not in asserted_clause {}".format(clause,self._asserted_clauses))
 
-        retract = swipy.swipy_predicate("retract", 1, None)
-        query = swipy.swipy_open_query(retract, lit)
-        r = swipy.swipy_next_solution(query)
-        swipy.swipy_close_query(query)
-
-        return r
+    def retract_all(self):
+        for cl in [cl for cl in self._asserted_clauses]:
+            self.retract(cl)
+        self._asserted_clauses = set()
 
     def has_solution(self, *query: Union[Atom, Not]):
         var_store = {}

--- a/src/pylo/engines/prolog/XSBProlog.py
+++ b/src/pylo/engines/prolog/XSBProlog.py
@@ -96,6 +96,9 @@ def _pyxsb_string_to_pylo(term: str):
 class XSBProlog(Prolog):
 
     def __init__(self, exec_path=None):
+        # Initializes is_released in case exec_path is not found (which calls release())
+        super().__init__()
+
         if exec_path is None:
             exec_path = os.getenv('XSB_HOME', None)
             raise Exception(f"Cannot find XSB_HOME environment variable")
@@ -103,7 +106,6 @@ class XSBProlog(Prolog):
         self._asserted_clauses = set()
         self._asserted_atoms = set()
 
-        super().__init__()
 
     def release(self):
         if not self.is_released:
@@ -155,12 +157,10 @@ class XSBProlog(Prolog):
                 return pyxsb.pyxsb_command_string(f"retract(({clause})).")
 
     def retract_all(self):
-        for cl in self._asserted_clauses:
+        for cl in [cl for cl in self._asserted_clauses]:
             self.retract(cl)
-        for cl in self._asserted_atoms:
+        for cl in [cl for cl in self._asserted_atoms]:
             self.retract(cl)
-        self._asserted_clauses = set()
-        self._asserted_atoms = set()
 
     def has_solution(self, *query: Atom):
         #assert not all([x.is_ground() for x in query]), "XSB Prolog currently cannot query ground queries"

--- a/src/pylo/engines/prolog/prologsolver.py
+++ b/src/pylo/engines/prolog/prologsolver.py
@@ -28,7 +28,11 @@ class Prolog(ABC):
         pass
 
     @abstractmethod
-    def retract(selfself, clause):
+    def retract(self, clause):
+        pass
+
+    @abstractmethod
+    def retract_all(self):
         pass
 
     @abstractmethod

--- a/src/pylo/language/commons.py
+++ b/src/pylo/language/commons.py
@@ -638,6 +638,21 @@ class Body:
 
         return vars_ordered
 
+    def get_arguments(self) -> Sequence[Variable]:
+        """
+        Returns the arguments of the literals in the body
+        """
+        args_ordered = []
+        args_covered = set()
+        for i in range(len(self._literals)):
+            to_add = [
+                x for x in self._literals[i].get_arguments() if x not in args_covered
+            ]
+            args_ordered += to_add
+            args_covered = args_covered.union(to_add)
+
+        return args_ordered
+
     def substitute(self, term_map: Dict[Term, Term]):
         return Body(*[x.substitute(term_map) for x in self._literals])
 
@@ -792,6 +807,12 @@ class Clause:
             Returns only the head variables
         """
         return self._head.get_variables()
+
+    def get_head_arguments(self) -> Sequence[Term]:
+        """
+        Returns only the head arguments
+        """
+        return self._head.get_arguments()
 
     def get_body_variables(self) -> Sequence[Variable]:
         """

--- a/src/pylo/tests/test_retractall.py
+++ b/src/pylo/tests/test_retractall.py
@@ -34,8 +34,8 @@ def test(pl):
 swipl = SWIProlog()
 test(swipl)
 
-xsb = XSBProlog()
+xsb = XSBProlog("/home/quinten/Software/XSB/")
 test(xsb)
 
-# gnu = GNUProlog()
-# test(gnu)
+gnu = GNUProlog()
+test(gnu)

--- a/src/pylo/tests/test_retractall.py
+++ b/src/pylo/tests/test_retractall.py
@@ -1,0 +1,41 @@
+from pylo.engines.prolog import (
+    SWIProlog, 
+    # GNUProlog, 
+    XSBProlog
+)
+from pylo.language.lp import c_pred, c_functor, c_var, List, c_const
+
+def test(pl):
+    pred1 = c_pred("pred1",1)
+    pred2 = c_pred("pred2",1)
+
+    const1 = c_const("const1")
+    const2 = c_const("const2")
+
+    x = c_var("X")
+    y = c_var("Y")
+
+    atoms = [ pred1(const1),pred1(const2),pred2(const1),pred2(const2) ]
+    for atom in atoms:
+        pl.assertz(atom)
+
+    q = pred1(x) # Should have 2 solutions: const1 and const2
+    assert len(pl.query(q)) == 2
+
+    pl.retract(atoms[0])    # q should have 1 solution: const
+    print(len(pl.query(q)))
+    assert len(pl.query(q)) == 1
+
+    pl.retract_all()    # Empty engine: no result for query
+    assert len(pl.query(pred1(x))) == 0
+    assert len(pl.query(pred2(x))) == 0
+
+
+swipl = SWIProlog()
+test(swipl)
+
+xsb = XSBProlog()
+test(xsb)
+
+# gnu = GNUProlog()
+# test(gnu)


### PR DESCRIPTION
This PR adds a `retract_all()` function to all 3 Prolog engines (SWIPL, XSB and GNUProlog). `retract_all()` retracts all previously asserted clauses from the engine, which allows you to start clean without creating a new engine object.

This fixes inconsistent behavior caused by the underlying engines: after calling release(), there is still knowledge asserted.

**Needs to be tested (tests/test_retractall.py) on OSX**